### PR TITLE
Implement admin remove organizers (US 03.07.01)

### DIFF
--- a/Code/EventPlanner/app/src/main/AndroidManifest.xml
+++ b/Code/EventPlanner/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         <activity android:name=".ProfileSetup" />
         <activity android:name=".AdminBrowseEventsActivity" />
         <activity android:name=".AdminBrowseImagesActivity" />
+        <activity android:name=".AdminRemoveOrganizersActivity" />
 
     </application>
 

--- a/Code/EventPlanner/app/src/main/java/com/example/eventplanner/AdminOrganizerAdapter.java
+++ b/Code/EventPlanner/app/src/main/java/com/example/eventplanner/AdminOrganizerAdapter.java
@@ -1,0 +1,72 @@
+package com.example.eventplanner;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.List;
+
+public class AdminOrganizerAdapter extends RecyclerView.Adapter<AdminOrganizerAdapter.OrganizerViewHolder> {
+
+    public interface OnOrganizerActionListener {
+        void onRemoveClicked(User organizer, int position);
+    }
+
+    private final List<User> organizers;
+    private final OnOrganizerActionListener listener;
+
+    public AdminOrganizerAdapter(List<User> organizers, OnOrganizerActionListener listener) {
+        this.organizers = organizers;
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public OrganizerViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_admin_organizer, parent, false);
+        return new OrganizerViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull OrganizerViewHolder holder, int position) {
+        User organizer = organizers.get(position);
+
+        holder.txtName.setText(safeText(organizer.getName(), "Unknown Organizer"));
+        holder.txtEmail.setText("Email: " + safeText(organizer.getEmail(), "N/A"));
+        holder.txtPhone.setText("Phone: " + safeText(organizer.getPhone(), "N/A"));
+
+        holder.btnRemoveOrganizer.setOnClickListener(v -> {
+            if (listener != null && holder.getAdapterPosition() != RecyclerView.NO_POSITION) {
+                listener.onRemoveClicked(organizer, holder.getAdapterPosition());
+            }
+        });
+    }
+
+    @Override
+    public int getItemCount() {
+        return organizers == null ? 0 : organizers.size();
+    }
+
+    static class OrganizerViewHolder extends RecyclerView.ViewHolder {
+        TextView txtName, txtEmail, txtPhone;
+        Button btnRemoveOrganizer;
+
+        public OrganizerViewHolder(@NonNull View itemView) {
+            super(itemView);
+            txtName = itemView.findViewById(R.id.txt_admin_organizer_name);
+            txtEmail = itemView.findViewById(R.id.txt_admin_organizer_email);
+            txtPhone = itemView.findViewById(R.id.txt_admin_organizer_phone);
+            btnRemoveOrganizer = itemView.findViewById(R.id.btn_admin_remove_organizer);
+        }
+    }
+
+    private String safeText(String value, String fallback) {
+        return (value == null || value.trim().isEmpty()) ? fallback : value;
+    }
+}

--- a/Code/EventPlanner/app/src/main/java/com/example/eventplanner/AdminRemoveOrganizersActivity.java
+++ b/Code/EventPlanner/app/src/main/java/com/example/eventplanner/AdminRemoveOrganizersActivity.java
@@ -1,0 +1,94 @@
+package com.example.eventplanner;
+
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AdminRemoveOrganizersActivity extends AppCompatActivity
+        implements AdminOrganizerAdapter.OnOrganizerActionListener {
+
+    private RecyclerView recyclerView;
+    private AdminOrganizerAdapter adapter;
+    private final List<User> organizerList = new ArrayList<>();
+    private final UserRepository userRepository = new UserRepository();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_admin_remove_organizers);
+
+        recyclerView = findViewById(R.id.recycler_admin_organizers);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+
+        adapter = new AdminOrganizerAdapter(organizerList, this);
+        recyclerView.setAdapter(adapter);
+
+        loadOrganizers();
+    }
+
+    private void loadOrganizers() {
+        userRepository.fetchAllUsers(new UserRepository.UsersCallback() {
+            @Override
+            public void onSuccess(List<User> users) {
+                organizerList.clear();
+
+                // Current repo does not store roles.
+                // For now, this screen displays users as removable organizers.
+                organizerList.addAll(users);
+
+                adapter.notifyDataSetChanged();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                Toast.makeText(AdminRemoveOrganizersActivity.this,
+                        "Failed to load organizers: " + e.getMessage(),
+                        Toast.LENGTH_LONG).show();
+            }
+        });
+    }
+
+    @Override
+    public void onRemoveClicked(User organizer, int position) {
+        if (organizer == null || organizer.getDeviceId() == null || organizer.getDeviceId().trim().isEmpty()) {
+            Toast.makeText(this, "This organizer cannot be removed.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        new AlertDialog.Builder(this)
+                .setTitle("Remove Organizer")
+                .setMessage("Are you sure you want to remove " + safeText(organizer.getName()) + "?")
+                .setPositiveButton("Remove", (dialog, which) -> {
+                    userRepository.deleteUser(organizer.getDeviceId(), new UserRepository.SimpleCallback() {
+                        @Override
+                        public void onSuccess() {
+                            organizerList.remove(position);
+                            adapter.notifyItemRemoved(position);
+                            Toast.makeText(AdminRemoveOrganizersActivity.this,
+                                    "Organizer removed successfully.",
+                                    Toast.LENGTH_SHORT).show();
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            Toast.makeText(AdminRemoveOrganizersActivity.this,
+                                    "Failed to remove organizer: " + e.getMessage(),
+                                    Toast.LENGTH_LONG).show();
+                        }
+                    });
+                })
+                .setNegativeButton("Cancel", null)
+                .show();
+    }
+
+    private String safeText(String value) {
+        return (value == null || value.trim().isEmpty()) ? "this organizer" : value;
+    }
+}

--- a/Code/EventPlanner/app/src/main/java/com/example/eventplanner/UserRepository.java
+++ b/Code/EventPlanner/app/src/main/java/com/example/eventplanner/UserRepository.java
@@ -3,11 +3,11 @@ package com.example.eventplanner;
 import androidx.annotation.NonNull;
 
 import com.google.firebase.firestore.FirebaseFirestore;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class UserRepository {
-
     private static final String COLLECTION_USERS = "users";
     private final FirebaseFirestore db;
 
@@ -52,7 +52,6 @@ public class UserRepository {
                 .addOnFailureListener(cb::onFailure);
     }
 
-
     public void fetchAllUsers(@NonNull UsersCallback cb) {
         db.collection(COLLECTION_USERS)
                 .get()
@@ -60,11 +59,20 @@ public class UserRepository {
                     List<User> out = new ArrayList<>();
                     for (var doc : snapshot.getDocuments()) {
                         User u = doc.toObject(User.class);
-                        if (u != null) out.add(u);
+                        if (u != null) {
+                            out.add(u);
+                        }
                     }
                     cb.onSuccess(out);
                 })
                 .addOnFailureListener(cb::onFailure);
     }
 
+    public void deleteUser(@NonNull String deviceId, @NonNull SimpleCallback cb) {
+        db.collection(COLLECTION_USERS)
+                .document(deviceId)
+                .delete()
+                .addOnSuccessListener(unused -> cb.onSuccess())
+                .addOnFailureListener(cb::onFailure);
+    }
 }

--- a/Code/EventPlanner/app/src/main/res/layout/activity_admin_remove_organizers.xml
+++ b/Code/EventPlanner/app/src/main/res/layout/activity_admin_remove_organizers.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="#1C1B2E"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Admin Remove Organizers"
+        android:textSize="24sp"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:layout_marginBottom="16dp"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_admin_organizers"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+</LinearLayout>

--- a/Code/EventPlanner/app/src/main/res/layout/item_admin_organizer.xml
+++ b/Code/EventPlanner/app/src/main/res/layout/item_admin_organizer.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:background="#2A2940"
+    android:padding="16dp"
+    android:layout_marginBottom="12dp">
+
+    <TextView
+        android:id="@+id/txt_admin_organizer_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Organizer Name"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:textSize="18sp"
+        android:layout_marginBottom="8dp"/>
+
+    <TextView
+        android:id="@+id/txt_admin_organizer_email"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Email: N/A"
+        android:textColor="#DDDDDD"
+        android:textSize="14sp"
+        android:layout_marginBottom="4dp"/>
+
+    <TextView
+        android:id="@+id/txt_admin_organizer_phone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Phone: N/A"
+        android:textColor="#DDDDDD"
+        android:textSize="14sp"
+        android:layout_marginBottom="12dp"/>
+
+    <Button
+        android:id="@+id/btn_admin_remove_organizer"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Remove Organizer"
+        android:textAllCaps="false"
+        android:textColor="#FFFFFF"
+        android:background="@drawable/button_purple"/>
+</LinearLayout>


### PR DESCRIPTION
This PR implements the admin organizer moderation feature.

User Story Implemented:
- US 03.07.01: As an administrator, I want to remove organizers that violate app policy.

Changes Made:
- Added AdminRemoveOrganizersActivity to allow administrators to browse organizers.
- Created AdminOrganizerAdapter to display organizer information in a RecyclerView.
- Added layout files for organizer list and organizer items.
- Implemented deleteUser() in UserRepository to remove organizers from the database.
- Registered AdminRemoveOrganizersActivity in AndroidManifest.

This allows administrators to view organizers and remove them if they violate application policies.