### PR TITLE
(hopefully) fixed bug with User Event History

### DIFF
--- a/Code/EventPlanner/app/src/main/java/com/example/eventplanner/EventHistoryActivity.java
+++ b/Code/EventPlanner/app/src/main/java/com/example/eventplanner/EventHistoryActivity.java
@@ -99,6 +99,9 @@ public class EventHistoryActivity extends AppCompatActivity {
                         String status  = doc.getString("status");
                         com.google.firebase.Timestamp joinedAt = doc.getTimestamp("joinedAt");
 
+                        // Don't show waitlisted events in history — they haven't concluded yet
+                        if ("waitlisted".equals(status)) continue;
+
                         if (eventId != null) {
                             eventIds.add(eventId);
                             statuses.add(status != null ? status : "unknown");
@@ -107,6 +110,9 @@ public class EventHistoryActivity extends AppCompatActivity {
                                     : "Unknown date");
                         }
                     }
+
+                    // If all registrations were waitlisted, then show the empty state
+                    if (eventIds.isEmpty()) return;
 
                     fetchEventsAndDisplay(eventIds, statuses, timestamps);
                 })

--- a/Code/EventPlanner/app/src/main/java/com/example/eventplanner/RegistrationRepository.java
+++ b/Code/EventPlanner/app/src/main/java/com/example/eventplanner/RegistrationRepository.java
@@ -65,7 +65,7 @@ public class RegistrationRepository {
         Map<String, Object> payload = new HashMap<>();
         payload.put("eventId", eventId);
         payload.put("userId", userId);
-        payload.put("status", "pending"); // pending, accepted, waitlisted, rejected
+        payload.put("status", "waitlisted"); // waitlisted, accepted, declined, rejected
         payload.put("joinedAt", Timestamp.now());
 
         db.collection(COLLECTION_REGISTRATIONS)


### PR DESCRIPTION
Just a simple PR where I fixed a bug with User Event History. Initially was viewing current waitlisted events as "unknown event"(s), which were declined. Should be fixed now though.